### PR TITLE
Change color scheme, use PEP-8 style, delete MDS theme

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -2,12 +2,9 @@ import dash
 import dash_core_components as dcc
 import dash_html_components as html
 from dash.dependencies import Input, Output
-external_stylesheets = ['https://codepen.io/chriddyp/pen/bWLwgP.css']
 import altair as alt
-import vega_datasets
 import pandas as pd
 import altair as alt
-import datetime as dt
 
 # Import cleaned data
 df = pd.read_csv('../data/supermarket_sales_clean.csv')

--- a/src/supermarket.py
+++ b/src/supermarket.py
@@ -1,283 +1,243 @@
-import pandas as pd
-import plotly.graph_objs as go
 import dash
-import dash_core_components as dcc                 
-import dash_html_components as html 
-import altair as alt                
-from dash.dependencies import Input, Output        
+import dash_core_components as dcc
+import dash_html_components as html
+from dash.dependencies import Input, Output
+import altair as alt
+import pandas as pd
+import altair as alt  
 
 app = dash.Dash(__name__, assets_folder='assets')
+app.config['suppress_callback_exceptions'] = True
+
 server = app.server
+app.title = 'Supermarket team scheduling dashboard'
 
-app.title = 'Supermarket Dashboard'
+# Import cleaned data
+# To run from `src` directory keep code below
+# To run from home directory, change path to '/data/supermarket_sales.csv'
 
-def mds_special():
-    font = "Arial"
-    axisColor = "#000000"
-    gridColor = "#DEDDDD"
-    return {
-        "config": {
-            "title": {
-                "fontSize": 24,
-                "font": font,
-                "anchor": "start", # equivalent of left-aligned.
-                "fontColor": "#000000"
-            },
-            'view': {
-                "height": 300, 
-                "width": 400
-            },
-            "axisX": {
-                "domain": True,
-                #"domainColor": axisColor,
-                "gridColor": gridColor,
-                "domainWidth": 1,
-                "grid": False,
-                "labelFont": font,
-                "labelFontSize": 12,
-                "labelAngle": 90, 
-                "tickColor": axisColor,
-                "tickSize": 5, # default, including it just to show you can change it
-                "titleFont": font,
-                "titleFontSize": 16,
-                "titlePadding": 10, # guessing, not specified in styleguide
-                "title": "X Axis Title (units)", 
-            },
-            "axisY": {
-                "domain": False,
-                "grid": True,
-                "gridColor": gridColor,
-                "gridWidth": 1,
-                "labelFont": font,
-                "labelFontSize": 14,
-                "labelAngle": 0, 
-                #"ticks": False, # even if you don't have a "domain" you need to turn these off.
-                "titleFont": font,
-                "titleFontSize": 16,
-                "titlePadding": 10, # guessing, not specified in styleguide
-                "title": "Y Axis Title (units)", 
-                # titles are by default vertical left of axis so we need to hack this 
-                #"titleAngle": 0, # horizontal
-                #"titleY": -10, # move it up
-                #"titleX": 18, # move it to the right so it aligns with the labels 
-            },
-        }
-            }
+df = pd.read_csv('../data/supermarket_sales_clean.csv')
 
-# register the custom theme under a chosen name
-alt.themes.register('mds_special', mds_special)
-
-# enable the newly registered theme
-alt.themes.enable('mds_special')
-
-# load data, .py should be run in `src` directory in this case 
-# if you are going to run from home directory, change path to '/data/supermarket_sales.csv'
-df = pd.read_csv('../data/supermarket_sales.csv',
-                 parse_dates = {'Date_time': ['Date', 'Time']})
-
-# Add day of the week
-df['Day_of_week'] = df['Date_time'].dt.weekday_name
-
-# Assign transactions between 09:00-12:59 as 'Morning'
-morning = df.set_index('Date_time').between_time('09:00', '12:59')
-morning['Time_of_day'] = 'Morning'
-
-# Assign transactions between 13:00-16:59 as 'Afternoon'
-afternoon = df.set_index('Date_time').between_time('13:00', '16:59')
-afternoon['Time_of_day'] = 'Afternoon'
-
-# Assign transactions between 17:00-20:59 as 'Evening'
-evening = df.set_index('Date_time').between_time('17:00', '20:59')
-evening['Time_of_day'] = 'Evening'
-
-new_df = pd.concat([morning, afternoon, evening])
-
-def update_heatmap(branch_index, func, pltTitle):
-    days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
-    times = ['Morning', 'Afternoon', 'Evening']
+def make_heat_map(branch_index, func, plot_title):
     
-    chart = alt.Chart(new_df).mark_rect().encode(
-     alt.X('Day_of_week:N', title=None, sort=days),
-     alt.Y('Time_of_day:N', title=None, sort=times),
-     alt.Color(func, type = 'quantitative' ,title=None, scale=alt.Scale(scheme='inferno'), sort="descending"),
-     tooltip=[alt.Tooltip('Day_of_week', title='Day of the week'), 
-              alt.Tooltip('Time_of_day', title="Time of the day"), 
-              alt.Tooltip('sum(Total):Q', title='Sales', format='$,.0f')]
-    ).transform_filter(
-            alt.FieldEqualPredicate(field='Branch', equal= branch_index)
-    ).properties(width=250, height=150, title=pltTitle
-    ).configure_axis(labelFontSize=14, titleFontSize=14
-    ).configure_title(fontSize=16)
-    return chart
-
-def con_heatmap1(branch_index = "A"):
-    plt1 = update_heatmap(branch_index, 'sum(Total)', "Total Sales")
-
-    return plt1
-
-def con_heatmap2(branch_index = "A"):
-    plt2 = update_heatmap(branch_index, 'count(Invoice ID)', "Customer Traffic")
-
-    return plt2
-
-def con_heatmap3(branch_index = "A"):
-    plt3 = update_heatmap(branch_index, "mean(Total)", "Average Transaction Size")
-
-    return plt3
-
-def con_heatmap4(branch_index = "A"):
-    plt4 = update_heatmap(branch_index, "mean(Rating)", "Average Satisfaction")
-
-    return plt4
-
-def update_graph(DayofWeek, TimeofDay, branch_index, func, pltTitle):
-    '''
-    plot barplots of different functions for specific DayofWeek and TimeofDay 
+    '''Make a bar plot filtered by branch
     
     Parameters
     ---
-    DayofWeek: Str
-    TimeofDay: Str
+    branch_index: Str
     func: Str
-    pltTitle: Str
+    plot_title: Str
+    '''
+    
+    days = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']
+    times = ['Morning', 'Afternoon', 'Evening']
+    
+    heat_map = (alt
+                .Chart(df)
+                .mark_rect()
+                .encode(alt.X('Day_of_week:N', title=None, sort=days),
+                        alt.Y('Time_of_day:N', title=None, sort=times),
+                        alt.Color(func, type = 'quantitative' ,title=None, scale=alt.Scale(scheme='greens')),
+                        tooltip=[alt.Tooltip('Day_of_week', title='Day of the week'), 
+                        alt.Tooltip('Time_of_day', title="Time of the day"),
+                        alt.Tooltip(func, type='quantitative', title=plot_title)])
+                        .transform_filter(alt.FieldEqualPredicate(field='Branch', equal= branch_index))
+                        .configure_axis(labelFontSize=13, titleFontSize=13)
+                        .configure_title(fontSize=14)
+                        .properties(width=180, height=130, title=plot_title)
+    )   
+    return heat_map
+    
+def make_total_sales(branch_index="A"):
+    total_sales = make_heat_map(branch_index, 'sum(Total)', "Total Sales")
+
+    return total_sales
+
+def make_customer_traffic(branch_index="A"):
+    customer_traffic = make_heat_map(branch_index, 'count(Invoice ID)', "Customer Traffic")
+
+    return customer_traffic
+
+def make_transaction_size(branch_index="A"):
+    transaction_size = make_heat_map(branch_index, "mean(Total)", "Average Transaction Size")
+
+    return transaction_size
+
+def make_customer_satisfaction(branch_index="A"):
+    customer_satisfaction = make_heat_map(branch_index, "mean(Rating)", "Average Satisfaction")
+
+    return customer_satisfaction
+
+def make_bar_plot(day_of_week, time_of_day, branch_index, func, plot_title):
+    '''Make a bar plot filtered by branch, day of week, and time of day 
+    
+    Parameters
+    ---
+    day_of_week: Str
+    time_of_day: Str
+    func: Str
+    plot_title: Str
     branch_index: Str
     '''
-    chart = alt.Chart(new_df).mark_bar(color = "cornflowerblue").encode(
-            alt.X('Product line:N'),
-            alt.Y(func, type ='quantitative'),
-            tooltip=[alt.Tooltip('Product line', title = 'Product line'),
-                     alt.Tooltip('Day_of_week', title = "Day of Week"),
-                     alt.Tooltip('Time_of_day', title = "Time of Day"),
-                     alt.Tooltip(func, title = pltTitle)]
-        ).transform_filter(
-            alt.FieldEqualPredicate(field='Branch', equal= branch_index)
-        ).transform_filter(
-            alt.FieldEqualPredicate(field='Day_of_week', equal= DayofWeek)
-        ).transform_filter(
-            alt.FieldEqualPredicate(field='Time_of_day', equal= TimeofDay)
-        ).properties(width=280, height=200, title= pltTitle)
-    return chart
+    bar_plot = (alt
+                .Chart(df)
+                .mark_bar(color = "cornflowerblue")
+                .encode(alt.X('Product line:N', title=None),
+                        alt.Y(func, type ='quantitative'),
+                        tooltip=[alt.Tooltip('Product line', title = 'Product line'),
+                                alt.Tooltip('Day_of_week', title = "Day of Week"),
+                                alt.Tooltip('Time_of_day', title = "Time of Day"),
+                                alt.Tooltip(func, title = plot_title)])
+                .transform_filter(alt.FieldEqualPredicate(field='Branch', equal= branch_index))
+                .transform_filter(alt.FieldEqualPredicate(field='Day_of_week', equal= day_of_week))
+                .transform_filter(alt.FieldEqualPredicate(field='Time_of_day', equal= time_of_day))
+                .properties(width=250, height=175, title= plot_title)
+    )
+    return bar_plot
 
-def con_plt(DayofWeek = "Monday", TimeofDay = "Morning", branch_index = "A"):
-    plt1 = update_graph(DayofWeek, TimeofDay, branch_index, 'sum(Total)', "Total Sales")
-    plt2 = update_graph(DayofWeek, TimeofDay, branch_index, 'count(Invoice ID)', "Customer Traffic")
-    plt3 = update_graph(DayofWeek, TimeofDay, branch_index, "mean(Total)", "Average Transaction Size")
-    plt4 = update_graph(DayofWeek, TimeofDay, branch_index, "mean(Rating)", "Average Satisfaction")
+def con_plt(day_of_week="Monday", time_of_day="Morning", branch_index="A"):
+    bar_plot_sales = make_bar_plot(day_of_week, time_of_day, branch_index, "sum(Total)", "Total Sales")
+    bar_plot_traffic = make_bar_plot(day_of_week,time_of_day, branch_index, "count(Invoice ID)", "Customer Traffic")
+    bar_plot_trans = make_bar_plot(day_of_week, time_of_day, branch_index, "mean(Total)", "Average Transaction Size")
+    bar_plot_rating = make_bar_plot(day_of_week, time_of_day, branch_index, "mean(Rating)", "Average Satisfaction")
     
-    return alt.concat(plt1, plt2, plt3, plt4, columns=4)
+    return (alt.concat(bar_plot_sales, bar_plot_traffic, bar_plot_trans, bar_plot_rating, columns=4)
+                .configure_axis(labelFontSize=13, titleFontSize=13)
+                .configure_title(fontSize=14)
+            )
 
 con_plt("Monday", "Morning", "A")
-con_heatmap1("A")
-con_heatmap2("A")
-con_heatmap3("A")
-con_heatmap4("A")
+make_total_sales("A")
+make_customer_traffic("A")
+make_transaction_size("A")
+make_customer_traffic("A")
 
 app.layout = html.Div([
     html.H1("Supermarket Dashboard"),
-    html.Label('Please choose Store'),
+    
+    html.Label('Select store:'),
+    
+    # Arrange radio buttoms to select branch
     dcc.RadioItems(
         id = 'Store',
         options = [{'label': i, 'value': i} for i in ["A", "B", "C"]],
         value = 'Branch'),
-    html.Iframe(
-        sandbox='allow-scripts',
-        id='plot2',
-        height='250',
-        width='342',
-        style={'border-width': '5px'},
-
-        srcDoc = con_heatmap1().to_html()
-        ),
-    html.Iframe(
-        sandbox='allow-scripts',
-        id='plot3',
-        height='250',
-        width='342',
-        style={'border-width': '5px'},
-
-        srcDoc = con_heatmap2().to_html()
-        ),
-    html.Iframe(
-        sandbox='allow-scripts',
-        id='plot4',
-        height='250',
-        width='342',
-        style={'border-width': '5px'},
-
-        srcDoc = con_heatmap2().to_html()
-        ),
-    html.Iframe(
-        sandbox='allow-scripts',
-        id='plot5',
-        height='250',
-        width='342',
-        style={'border-width': '5px'},
-
-        srcDoc = con_heatmap2().to_html()
-        ),
-    html.Label('Please choose Day of Week'),
+    
+    html.Div([
+        # Arrange total sales heat map
+        html.Iframe(
+            sandbox='allow-scripts',
+            id='total_sales',
+            height='300',
+            width='370',
+            style={'border-width': '0px'},
+            srcDoc = make_total_sales().to_html()
+            ),
+        
+        # Arrange customer traffic heat map
+        html.Iframe(
+            sandbox='allow-scripts',
+            id='customer_traffic',
+            height='300',
+            width='370',
+            style={'border-width': '0px'},
+            srcDoc = make_customer_traffic().to_html()
+            ),
+        
+        # Arrange average transaction size heat map
+        html.Iframe(
+            sandbox='allow-scripts',
+            id='transaction_size',
+            height='300',
+            width='370',
+            style={'border-width': '0px'},
+            srcDoc = make_transaction_size().to_html()
+            ),
+        
+        # Arrange customer satisfaction heat map
+        html.Iframe(
+            sandbox='allow-scripts',
+            id='customer_satisfaction',
+            height='300',
+            width='370',
+            style={'border-width': '0px'},
+            srcDoc = make_customer_satisfaction().to_html()
+            )
+    ]),
+    
+    html.Label('Select day of week:'),
+    
+    # Arrange dropdown menu to select day of week
     dcc.Dropdown(
-        id = 'DayofWeek',
+        id = 'day_of_week',
         options = [{'label': i, 'value': i} for i in ["Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday", "Sunday"]],
         value = 'Day of Week'),
-    html.Label('Please choose Time of Day'),
+    
+    html.Label('Select time of day:'),
+    
+    # Arrange dropdown menu to select time of day
     dcc.Dropdown(
-        id = 'TimeofDay',
-        options = [{'label': i, 'value': i} for i in new_df['Time_of_day'].unique()],
+        id = 'time_of_day',
+        options = [{'label': i, 'value': i} for i in df['Time_of_day'].unique()],
         value = 'Time of Day'),
+    
+    # Arrange bar plots
     html.Iframe(
         sandbox='allow-scripts',
-        id='plot',
+        id='bar_plots',
         height='400',
-        width='1400',
-        style={'border-width': '5px'},
-
+        width='1500',
+        style={'border-width': '0px'},
         srcDoc = con_plt().to_html()
         ),
 ])
 
+# Update bar plots
 @app.callback(
-    dash.dependencies.Output('plot', 'srcDoc'),
-    [dash.dependencies.Input('DayofWeek', 'value'),
-     dash.dependencies.Input('TimeofDay', 'value'),
+    dash.dependencies.Output('bar_plots', 'srcDoc'),
+    [dash.dependencies.Input('day_of_week', 'value'),
+     dash.dependencies.Input('time_of_day', 'value'),
      dash.dependencies.Input('Store', 'value')])
 
-def update_plot(DayofWeek, TimeofDay, branch_index):
-    updated_plot = con_plt(DayofWeek, TimeofDay, branch_index).to_html()
-    return updated_plot
+def update_plot(day_of_week, time_of_day, branch_index):
+    bar_plots = con_plt(day_of_week, time_of_day, branch_index).to_html()
+    return bar_plots
 
+# Update total sales heat map
 @app.callback(
-    dash.dependencies.Output('plot2', 'srcDoc'),
+    dash.dependencies.Output('total_sales', 'srcDoc'),
     [dash.dependencies.Input('Store', 'value')])
 
 def update_plot(branch_index):
-    updated_plot2 = con_heatmap1(branch_index).to_html()
-    return updated_plot2
+    updated_sales = make_total_sales(branch_index).to_html()
+    return updated_sales
 
+# Update customer traffic heat map
 @app.callback(
-    dash.dependencies.Output('plot3', 'srcDoc'),
+    dash.dependencies.Output('customer_traffic', 'srcDoc'),
     [dash.dependencies.Input('Store', 'value')])
 
 def update_plot(branch_index):
-    updated_plot3 = con_heatmap2(branch_index).to_html()
-    return updated_plot3
+    updated_ct = make_customer_traffic(branch_index).to_html()
+    return updated_ct
 
+# Update average transaction size heat map
 @app.callback(
-    dash.dependencies.Output('plot4', 'srcDoc'),
+    dash.dependencies.Output('transaction_size', 'srcDoc'),
     [dash.dependencies.Input('Store', 'value')])
 
 def update_plot(branch_index):
-    updated_plot4 = con_heatmap3(branch_index).to_html()
-    return updated_plot4
+    updated_ts = make_transaction_size(branch_index).to_html()
+    return updated_ts
 
+# Update customer satisfaction heat map
 @app.callback(
-    dash.dependencies.Output('plot5', 'srcDoc'),
+    dash.dependencies.Output('customer_satisfaction', 'srcDoc'),
     [dash.dependencies.Input('Store', 'value')])
 
 def update_plot(branch_index):
-    updated_plot5 = con_heatmap4(branch_index).to_html()
-    return updated_plot5
-
+    updated_cs= make_customer_satisfaction(branch_index).to_html()
+    return updated_cs
 
 if __name__ == '__main__':
     app.run_server(debug=True)


### PR DESCRIPTION
What I did:
- Changed the color scheme of the heat maps
- Changed code to PEP-8 style (e.g. variable names, chaining)
- Added comments and changed function names for readibility
- Deleted MDS theme (since we weren't using it)
- Now importing cleaned data (already wrangled)

What to do:
- PEP-8 docstrings for functions
- Tool tips: decimal places? Also removed '$' from tool tip in the heat map since that was being used across all the heat maps.
- Show actual branch names instead of A, B, and C?
- Set defaults for heatmaps and barplots
- Choose and stick to single versus double quotations where possible!
- DEPLOY ON HEROKU @moniquewong 